### PR TITLE
Arduino IDE Library Manager compatibility fix

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=I2C-Sensor-Lib (iLib)
+name=I2C-Sensor-Lib iLib
 version=0.8.1
 author=Ingmar Splitt
 maintainer=Ingmar Splitt


### PR DESCRIPTION
Fix for error:

```
The library "I2C-Sensor-Lib_(iLib)" cannot be used.
Library names must contain only basic letters and numbers.
(ASCII only and no spaces, and it cannot start with a number)
```
