### PR TITLE
Fix vcc calculation

### DIFF
--- a/src/atmel_vcc.h
+++ b/src/atmel_vcc.h
@@ -28,7 +28,7 @@ int32_t readVcc() {
 
   int32_t result = (high<<8) | low;
 
-  result = 1125300L / result; // Calculate Vcc (in mV); 1125300 = 1.1*1023*1000
+  result = 1126400L / result; // Calculate Vcc (in mV); 1126400 = 1.1*1024*1000
   return result; // Vcc in millivolts
 };
 


### PR DESCRIPTION
The resolution of the used AVR controller is 10 bit and 10 bit means 1024 different states.
So for the calculation we have to use 1024 and not 1023. Because 1023 is the maximum value of a 10 bit ADC but not the resolution.

It is easier to understand with an 3 bit [ADC](https://en.wikipedia.org/wiki/Analog-to-digital_converter) example. 3 bit means 8 different measurement states.
The first state is 0 and the last state is 7 ( 2^3 - 1 ). For example possible values with an reference voltage 1 V are:

| ADC value | voltage in V |
|---------------|----------------|
| 0 | 0,0 |
| 1 | 0,125 |
| 2 | 0,250 |
| 3 | 0,375 |
| 4 | 0,500 |
| 5 | 0,625 |
| 6 | 0,750 |
| 7 | 0,875 |

The maximum voltage we can measure in this example is the reference voltage minus one [LSB](https://en.wikipedia.org/wiki/Least_significant_bit) (1 V - 0,125 V = 0,875 V).

If we get value 6 from the ADC means we have measured 0,75 V. But if we use 7 and not 8 for the calculation we get not the truth voltage: 1 V / 7 * 6 = 0,857.
If we are using the ADC resolution for our calculation we get: 1 V / 8 * 6 = 0,75 V.

So i hope you can understand why we have to use 1024 and not 1023?