### PR TITLE
Limit advertised architectural compatibility of this library to avr.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Library for i2c-sensors and some other specific functions (fast eFn, HD
 paragraph=The following sensors can be used with an uniform interface: Austria Microsystems TCS3772 light sensor - RGB and clear, Silicon Labs SI7021 humidity sensor, Invensense MPU9250 9DOF - 3 axis acceleration and gyro PLUS AK8963-IC with magnetic-field sensor, Freescale MPL3115A2 pressure, Maxim MAX44009 ambient and lux with incredible wide dynamic, NXP PCF2127 Realtime-Clock with 2ppm, Bosch BMP280 pressure, ST L3G-Series 3 axis gyro / angular rate, Freescale MAG3110 3 axis Compass / Magnetic field, Freescale MMA8451 3 axis acceleration, Fairchild FAN5421 Single-Cell Li-Ion Switching Charger, STM LPS331 Pressure Sensor, Maxim MAX17047 Fuel Gauge for various Cells
 category=Sensors
 url=https://github.com/orgua/iLib
-architectures=*
+architectures=avr


### PR DESCRIPTION
Otherwise unwitting Arduino users are misled to believe that this library will work on any Arduino platform, which is clearly not the case.